### PR TITLE
Improve symlink creation & error detection

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Packager (ordered by revision number).
 
+0.1.4 Jan 14 2019
+   - [FIX] Fix symlink creation
+   - [FIX] Improve detection of fpm errors
+
 0.1.3 Dec 01 2018
    - [FEATURE] Add support for symbolic links.
 

--- a/lib/packager/executor.rb
+++ b/lib/packager/executor.rb
@@ -74,6 +74,7 @@ class Packager
 
       x = `#{cmd.to_system.join(' ')}`
       rv = eval(x)
+      raise rv[:error] if rv[:error]
       raise rv[:message] if rv[:level] == :error
       return rv[:path]
     end

--- a/lib/packager/executor.rb
+++ b/lib/packager/executor.rb
@@ -37,8 +37,6 @@ class Packager
           dest = (file.dest || '').gsub /^\//, ''
           FileUtils.mkdir_p File.dirname(dest)
           if file.link
-            source = (file.source || '').gsub /^\//, ''
-            FileUtils.mkdir_p File.dirname(source)
             FileUtils.ln_s(file.source, dest, force: true)
           else
             FileUtils.cp_r(file.source, dest)

--- a/lib/packager/executor.rb
+++ b/lib/packager/executor.rb
@@ -76,7 +76,7 @@ class Packager
 
       x = `#{cmd.to_system.join(' ')}`
       rv = eval(x)
-      raise rv[:error] if rv[:error]
+      raise rv[:message] if rv[:level] == :error
       return rv[:path]
     end
   end

--- a/lib/packager/executor.rb
+++ b/lib/packager/executor.rb
@@ -37,7 +37,9 @@ class Packager
           dest = (file.dest || '').gsub /^\//, ''
           FileUtils.mkdir_p File.dirname(dest)
           if file.link
-            FileUtils.ln_s(file.source, dest)
+            source = (file.source || '').gsub /^\//, ''
+            FileUtils.mkdir_p File.dirname(source)
+            FileUtils.ln_s(file.source, dest, force: true)
           else
             FileUtils.cp_r(file.source, dest)
           end

--- a/lib/packager/version.rb
+++ b/lib/packager/version.rb
@@ -1,3 +1,3 @@
 class Packager
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/spec/executor/execute_command_spec.rb
+++ b/spec/executor/execute_command_spec.rb
@@ -6,7 +6,16 @@ describe Packager::Executor do
   end
 
   context "#execute_command" do
-    it "handles errors" do
+    it "handles errors indicated by the presence of :error key" do
+      cmd = Packager::Struct::TestCommand.new(
+        :command => ["echo '{:error=>\"foo\"}'"]
+      )
+      expect {
+        subject.execute_command(cmd)
+      }.to raise_error('foo')
+    end
+
+    it "handles errors indicated by the presence of :level=>:error" do
       cmd = Packager::Struct::TestCommand.new(
         :command => ["echo '{:message=>\"foo\", :level=>:error}'"]
       )

--- a/spec/executor/execute_command_spec.rb
+++ b/spec/executor/execute_command_spec.rb
@@ -8,7 +8,7 @@ describe Packager::Executor do
   context "#execute_command" do
     it "handles errors" do
       cmd = Packager::Struct::TestCommand.new(
-        :command => ["echo '{:error=>\"foo\"}'"]
+        :command => ["echo '{:message=>\"foo\", :level=>:error}'"]
       )
       expect {
         subject.execute_command(cmd)


### PR DESCRIPTION
Symlinks to nonexistent locations were not being created upon install. Also, my ArchLinux system was missing `rpmbuild` so `packager` silently failed to produce package files. I believe now `Package::Executor#create_package_for` is correctly able to detect errors.

Thank you for your work on this gem.

Now that I have corrected some of my misunderstandings, I think this also handles issue #10 and partially handles #7.